### PR TITLE
fix: restore target quality filters in similar manga algorithm

### DIFF
--- a/cmd/calculate/similar.go
+++ b/cmd/calculate/similar.go
@@ -457,6 +457,12 @@ func processManga(idx int, data *SimilarityData, config processingConfig, progre
 			dDesc = 0
 		}
 
+		if len(data.MangaList[i].Tags) < IgnoreTagsUnderCount {
+			dTag = 1
+		}
+		if dDesc < IgnoreDescScoreUnder || data.CorpusDescLength[i] < MinDescriptionWords {
+			dDesc = 0
+		}
 		if dDesc > AcceptDescScoreOver {
 			dTag = 1
 		}

--- a/cmd/calculate/similar.go
+++ b/cmd/calculate/similar.go
@@ -457,15 +457,12 @@ func processManga(idx int, data *SimilarityData, config processingConfig, progre
 			dDesc = 0
 		}
 
-		if len(data.MangaList[i].Tags) < IgnoreTagsUnderCount {
-			dTag = 1
-		}
-		if dDesc < IgnoreDescScoreUnder || data.CorpusDescLength[i] < MinDescriptionWords {
-			dDesc = 0
-		}
-		if dDesc > AcceptDescScoreOver {
-			dTag = 1
-		}
+        if dDesc < IgnoreDescScoreUnder || data.CorpusDescLength[i] < MinDescriptionWords {
+            dDesc = 0
+        }
+        if len(data.MangaList[i].Tags) < IgnoreTagsUnderCount || dDesc > AcceptDescScoreOver {
+            dTag = 1
+        }
 
 		score := TagScoreRatio*dTag + dDesc
 		if score <= 0 {


### PR DESCRIPTION
The similarity calculation algorithm dropped quality checks for target manga metadata, causing worse matches. I've restored the `IgnoreTagsUnderCount` and `IgnoreDescScoreUnder` logic inside `processManga` to ensure sparse target data doesn't penalize overall similarity scores.

---
*PR created automatically by Jules for task [17055444850568580976](https://jules.google.com/task/17055444850568580976) started by @nonproto*