### PR TITLE
🔒 [security fix] Fix SQL injection in getAllMappings

### DIFF
--- a/cmd/neko/neko.go
+++ b/cmd/neko/neko.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"io"
 	"iter"
+	"log"
 	"os"
 	"time"
 )
@@ -98,6 +99,13 @@ func setNekoField(nekoEntry *internal.DbNeko, table, value string) {
 }
 
 func getAllMappings(table string) map[string]string {
+	switch table {
+	case internal.TableAnilist, internal.TableAnimePlanet, internal.TableBookWalker, internal.TableKitsu, internal.TableMyanimelist, internal.TableMangaupdates, internal.TableMangaupdatesNewId, internal.TableNovelUpdates:
+		// OK
+	default:
+		log.Fatalf("getAllMappings: invalid table name %s", table)
+	}
+
 	rows, err := internal.DB.Query("SELECT UUID, ID FROM " + table)
 	internal.CheckErr(err)
 	defer rows.Close()

--- a/cmd/neko/neko_test.go
+++ b/cmd/neko/neko_test.go
@@ -1,13 +1,40 @@
 package neko
 
 import (
+	"bytes"
 	"database/sql"
+	"os"
+	"os/exec"
 	"slices"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/similar-manga/similar/internal"
 )
+
+func TestGetAllMappings(t *testing.T) {
+	t.Run("invalid table name", func(t *testing.T) {
+		if os.Getenv("BE_CRASHER") == "1" {
+			getAllMappings("INVALID_TABLE")
+			return
+		}
+		cmd := exec.Command(os.Args[0], "-test.run=^TestGetAllMappings/invalid_table_name$")
+		cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+
+		if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+			const expectedLog = "getAllMappings: invalid table name"
+			if !strings.Contains(stderr.String(), expectedLog) {
+				t.Errorf("expected stderr to contain %q, got %q", expectedLog, stderr.String())
+			}
+			return
+		}
+		t.Fatalf("process ran with err %v, want exit status 1. stderr: %s", err, stderr.String())
+	})
+}
 
 func TestProcessMangaList(t *testing.T) {
 	// Setup Output DB


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a SQL injection in the `getAllMappings` function within `cmd/neko/neko.go`.
⚠️ **Risk:** If left unfixed, an attacker could potentially execute arbitrary SQL commands by manipulating the `table` parameter, leading to unauthorized data access or database modification.
🛡️ **Solution:** The fix implements a strict whitelist validation for the `table` name against known allowed constants before it is used in the SQL query.

---
*PR created automatically by Jules for task [5523406989861435868](https://jules.google.com/task/5523406989861435868) started by @nonproto*