### PR TITLE
🧪 Add tests for CheckAndAddLegacyId

### DIFF
--- a/cmd/calculate/mappingHelpers_test.go
+++ b/cmd/calculate/mappingHelpers_test.go
@@ -1,0 +1,242 @@
+package calculate
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/similar-manga/similar/internal"
+	"go.uber.org/ratelimit"
+)
+
+type mockTransport struct {
+	RoundTripFunc func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.RoundTripFunc(req)
+}
+
+func TestCheckAndAddLegacyId(t *testing.T) {
+	_, teardown := setupTestDB(t)
+	defer teardown()
+
+	// Ensure the table exists
+	_, err := internal.DB.Exec("CREATE TABLE " + internal.TableMangaupdatesNewId + " (UUID TEXT PRIMARY KEY, ID TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Save original client and restore after tests
+	oldClient := httpClient
+	defer func() { httpClient = oldClient }()
+
+	tests := []struct {
+		name          string
+		uuid          string
+		muLink        string
+		setupDB       func()
+		mockResp      func(req *http.Request) (*http.Response, error)
+		expectedResult bool
+		verify        func(t *testing.T)
+	}{
+		{
+			name:   "Invalid muLink (no digits)",
+			uuid:   "uuid1",
+			muLink: "no-digits-here",
+			mockResp: func(req *http.Request) (*http.Response, error) {
+				return nil, nil // Should not be called
+			},
+			expectedResult: false,
+		},
+		{
+			name:   "Entry already exists in DB",
+			uuid:   "uuid2",
+			muLink: "https://www.mangaupdates.com/series.html?id=12345",
+			setupDB: func() {
+				_, _ = internal.DB.Exec("INSERT INTO "+internal.TableMangaupdatesNewId+" (UUID, ID) VALUES (?, ?)", "uuid2", "12345")
+			},
+			mockResp: func(req *http.Request) (*http.Response, error) {
+				return nil, nil // Should not be called
+			},
+			expectedResult: true,
+		},
+		{
+			name:   "API returns 200 (Success)",
+			uuid:   "uuid3",
+			muLink: "https://www.mangaupdates.com/series.html?id=67890",
+			mockResp: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, "/v1/series/67890") {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+					}, nil
+				}
+				return &http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(""))}, nil
+			},
+			expectedResult: true,
+			verify: func(t *testing.T) {
+				var id string
+				err := internal.DB.QueryRow("SELECT ID FROM "+internal.TableMangaupdatesNewId+" WHERE UUID = ?", "uuid3").Scan(&id)
+				if err != nil {
+					t.Errorf("failed to find entry in DB: %v", err)
+				}
+				if id != "67890" {
+					t.Errorf("expected ID 67890, got %s", id)
+				}
+			},
+		},
+		{
+			name:   "API fails, Web scraping succeeds",
+			uuid:   "uuid4",
+			muLink: "https://www.mangaupdates.com/series.html?id=11111",
+			mockResp: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, "/v1/series/11111") {
+					return &http.Response{
+						StatusCode: 404,
+						Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+					}, nil
+				}
+				if strings.Contains(req.URL.Path, "series.html") && req.URL.Query().Get("id") == "11111" {
+					html := `<html><body><div id="main_content"><div></div><div><div class="row no-gutters"><div class="col-12 p-2"><a href="https://api.mangaupdates.com/v1/series/22222/rss">RSS</a></div></div></div></div></body></html>`
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewBufferString(html)),
+					}, nil
+				}
+				return &http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(""))}, nil
+			},
+			expectedResult: true,
+			verify: func(t *testing.T) {
+				var id string
+				err := internal.DB.QueryRow("SELECT ID FROM "+internal.TableMangaupdatesNewId+" WHERE UUID = ?", "uuid4").Scan(&id)
+				if err != nil {
+					t.Errorf("failed to find entry in DB: %v", err)
+				}
+				// Note: the code upserts convertedId (11111) not rssId (22222) if I read it correctly
+				// upsertNewMuId(uuid, convertedId)
+				if id != "11111" {
+					t.Errorf("expected ID 11111, got %s", id)
+				}
+			},
+		},
+		{
+			name:   "API returns 503 (Bad ID)",
+			uuid:   "uuid5",
+			muLink: "https://www.mangaupdates.com/series.html?id=55555",
+			mockResp: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, "/v1/series/55555") {
+					return &http.Response{
+						StatusCode: 404,
+						Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+					}, nil
+				}
+				if strings.Contains(req.URL.Path, "series.html") && req.URL.Query().Get("id") == "55555" {
+					return &http.Response{
+						StatusCode: 503,
+						Body:       io.NopCloser(bytes.NewBufferString("Service Unavailable")),
+					}, nil
+				}
+				return &http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(""))}, nil
+			},
+			expectedResult: false,
+			verify: func(t *testing.T) {
+				debugFile := filepath.Join("debug", "BadMUIds.txt")
+				if _, err := os.Stat(debugFile); os.IsNotExist(err) {
+					t.Errorf("expected debug file %s to exist", debugFile)
+				}
+				content, _ := os.ReadFile(debugFile)
+				if !strings.Contains(string(content), "https://mangadex.org/title/uuid5") {
+					t.Errorf("debug file does not contain expected link")
+				}
+				_ = os.Remove(debugFile)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear table for each test
+			_, _ = internal.DB.Exec("DELETE FROM " + internal.TableMangaupdatesNewId)
+			if tt.setupDB != nil {
+				tt.setupDB()
+			}
+
+			httpClient = &http.Client{
+				Transport: &mockTransport{
+					RoundTripFunc: tt.mockResp,
+				},
+			}
+
+			result := CheckAndAddLegacyId(0, 1, tt.uuid, tt.muLink, ratelimit.NewUnlimited())
+
+			if result != tt.expectedResult {
+				t.Errorf("expected result %v, got %v", tt.expectedResult, result)
+			}
+
+			if tt.verify != nil {
+				tt.verify(t)
+			}
+		})
+	}
+}
+
+func TestCheckAndAddLegacyId_Retry429(t *testing.T) {
+	_, teardown := setupTestDB(t)
+	defer teardown()
+
+	_, err := internal.DB.Exec("CREATE TABLE " + internal.TableMangaupdatesNewId + " (UUID TEXT PRIMARY KEY, ID TEXT)")
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	oldClient := httpClient
+	defer func() { httpClient = oldClient }()
+
+	callCount := 0
+	httpClient = &http.Client{
+		Transport: &mockTransport{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, "/v1/series/99999") {
+					return &http.Response{
+						StatusCode: 404,
+						Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+					}, nil
+				}
+				if strings.Contains(req.URL.Path, "series.html") {
+					callCount++
+					if callCount == 1 {
+						return &http.Response{
+							StatusCode: 429,
+							Body:       io.NopCloser(bytes.NewBufferString("Too Many Requests")),
+						}, nil
+					}
+					// Return success on second try to avoid long wait in tests
+					html := `<html><body><div id="main_content"><div></div><div><div class="row no-gutters"><div class="col-12 p-2"><a href="https://api.mangaupdates.com/v1/series/99999/rss">RSS</a></div></div></div></div></body></html>`
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewBufferString(html)),
+					}, nil
+				}
+				return &http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(""))}, nil
+			},
+		},
+	}
+
+	// We use a small muLink that will trigger the retry.
+	// We might want to mock time.Sleep to avoid the 2s delay, but for now we'll just wait.
+	// Actually, let's just test that it retries.
+
+	result := CheckAndAddLegacyId(0, 1, "uuid_retry", "https://www.mangaupdates.com/series.html?id=99999", ratelimit.NewUnlimited())
+
+	if !result {
+		t.Errorf("expected success after retry")
+	}
+	if callCount < 2 {
+		t.Errorf("expected at least 2 calls due to 429 retry, got %d", callCount)
+	}
+}

--- a/cmd/calculate/mappingHelpers_test.go
+++ b/cmd/calculate/mappingHelpers_test.go
@@ -21,28 +21,34 @@ func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return m.RoundTripFunc(req)
 }
 
-func TestCheckAndAddLegacyId(t *testing.T) {
+func setupTestDBWithTable(t *testing.T) func() {
+	t.Helper()
 	_, teardown := setupTestDB(t)
-	defer teardown()
 
 	// Ensure the table exists
-	_, err := internal.DB.Exec("CREATE TABLE " + internal.TableMangaupdatesNewId + " (UUID TEXT PRIMARY KEY, ID TEXT)")
+	_, err := internal.DB.Exec("CREATE TABLE IF NOT EXISTS " + internal.TableMangaupdatesNewId + " (UUID TEXT PRIMARY KEY, ID TEXT)")
 	if err != nil {
 		t.Fatalf("failed to create table: %v", err)
 	}
+	return teardown
+}
+
+func TestCheckAndAddLegacyId(t *testing.T) {
+	teardown := setupTestDBWithTable(t)
+	defer teardown()
 
 	// Save original client and restore after tests
 	oldClient := httpClient
 	defer func() { httpClient = oldClient }()
 
 	tests := []struct {
-		name          string
-		uuid          string
-		muLink        string
-		setupDB       func()
-		mockResp      func(req *http.Request) (*http.Response, error)
+		name           string
+		uuid           string
+		muLink         string
+		setupDB        func()
+		mockResp       func(req *http.Request) (*http.Response, error)
 		expectedResult bool
-		verify        func(t *testing.T)
+		verify         func(t *testing.T)
 	}{
 		{
 			name:   "Invalid muLink (no digits)",
@@ -117,8 +123,6 @@ func TestCheckAndAddLegacyId(t *testing.T) {
 				if err != nil {
 					t.Errorf("failed to find entry in DB: %v", err)
 				}
-				// Note: the code upserts convertedId (11111) not rssId (22222) if I read it correctly
-				// upsertNewMuId(uuid, convertedId)
 				if id != "11111" {
 					t.Errorf("expected ID 11111, got %s", id)
 				}
@@ -146,14 +150,16 @@ func TestCheckAndAddLegacyId(t *testing.T) {
 			expectedResult: false,
 			verify: func(t *testing.T) {
 				debugFile := filepath.Join("debug", "BadMUIds.txt")
-				if _, err := os.Stat(debugFile); os.IsNotExist(err) {
-					t.Errorf("expected debug file %s to exist", debugFile)
+				t.Cleanup(func() { _ = os.Remove(debugFile) })
+
+				content, err := os.ReadFile(debugFile)
+				if err != nil {
+					t.Errorf("expected debug file %s to exist and be readable: %v", debugFile, err)
+					return
 				}
-				content, _ := os.ReadFile(debugFile)
 				if !strings.Contains(string(content), "https://mangadex.org/title/uuid5") {
 					t.Errorf("debug file does not contain expected link")
 				}
-				_ = os.Remove(debugFile)
 			},
 		},
 	}
@@ -186,13 +192,8 @@ func TestCheckAndAddLegacyId(t *testing.T) {
 }
 
 func TestCheckAndAddLegacyId_Retry429(t *testing.T) {
-	_, teardown := setupTestDB(t)
+	teardown := setupTestDBWithTable(t)
 	defer teardown()
-
-	_, err := internal.DB.Exec("CREATE TABLE " + internal.TableMangaupdatesNewId + " (UUID TEXT PRIMARY KEY, ID TEXT)")
-	if err != nil {
-		t.Fatalf("failed to create table: %v", err)
-	}
 
 	oldClient := httpClient
 	defer func() { httpClient = oldClient }()
@@ -226,10 +227,6 @@ func TestCheckAndAddLegacyId_Retry429(t *testing.T) {
 			},
 		},
 	}
-
-	// We use a small muLink that will trigger the retry.
-	// We might want to mock time.Sleep to avoid the 2s delay, but for now we'll just wait.
-	// Actually, let's just test that it retries.
 
 	result := CheckAndAddLegacyId(0, 1, "uuid_retry", "https://www.mangaupdates.com/series.html?id=99999", ratelimit.NewUnlimited())
 


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `CheckAndAddLegacyId` function in `cmd/calculate/mappingHelpers.go` was previously untested. This function contains critical logic for legacy ID conversion, including regex parsing, API interaction, web scraping fallbacks, and retry mechanisms.

### 📊 Coverage: What scenarios are now tested
Implemented a new test file `cmd/calculate/mappingHelpers_test.go` using a table-driven approach that covers:
- **Input Validation:** Ensuring it returns false for `muLink` with no digits.
- **Database Cache:** Verifying it returns true early if the entry is already in the database.
- **API Success:** Simulating a successful 200 response from the MangaUpdates API.
- **Web Scraping Fallback:** Simulating a 404 from the API followed by successful HTML scraping of the RSS ID.
- **Error Handling:** Verifying 503 errors log correctly to `debug/BadMUIds.txt`.
- **Resilience:** Testing the retry logic when encountering HTTP 429 (Rate Limited) responses.

### ✨ Result: The improvement in test coverage
Increased the reliability and test coverage of the mapping calculation pipeline. Note: While tests were verified for logical correctness and reviewed, full execution in the sandbox was limited by external dependency resolution constraints.

---
*PR created automatically by Jules for task [14001660360513873118](https://jules.google.com/task/14001660360513873118) started by @nonproto*