### PR TITLE
🧹 [code health] replace panic with tb.Fatal in mangadex tests

### DIFF
--- a/cmd/mangadex/helpers_test.go
+++ b/cmd/mangadex/helpers_test.go
@@ -24,6 +24,14 @@ func setupTestDB(tb testing.TB) *sql.DB {
 	if err != nil {
 		tb.Fatal(err)
 	}
+
+	oldDB := internal.DB
+	internal.DB = db
+	tb.Cleanup(func() {
+		_ = db.Close()
+		internal.DB = oldDB
+	})
+
 	_, err = db.Exec("CREATE TABLE " + internal.TableManga + " (UUID TEXT PRIMARY KEY, JSON TEXT, DATE TEXT)")
 	if err != nil {
 		tb.Fatal(err)
@@ -46,9 +54,7 @@ func setupTestDB(tb testing.TB) *sql.DB {
 }
 
 func BenchmarkExistsInDatabase(b *testing.B) {
-	db := setupTestDB(b)
-	defer db.Close()
-	internal.DB = db
+	setupTestDB(b)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -57,9 +63,7 @@ func BenchmarkExistsInDatabase(b *testing.B) {
 }
 
 func BenchmarkGetExistingMangaUUIDs(b *testing.B) {
-	db := setupTestDB(b)
-	defer db.Close()
-	internal.DB = db
+	setupTestDB(b)
 
 	batchSize := 100
 	b.ResetTimer()
@@ -74,9 +78,7 @@ func BenchmarkGetExistingMangaUUIDs(b *testing.B) {
 }
 
 func TestExistsInDatabase(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	internal.DB = db
+	setupTestDB(t)
 
 	// Test existing
 	if !ExistsInDatabase("uuid-1") {
@@ -90,9 +92,7 @@ func TestExistsInDatabase(t *testing.T) {
 }
 
 func TestGetExistingMangaUUIDs(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	internal.DB = db
+	setupTestDB(t)
 
 	uuids := []string{"uuid-1", "uuid-2", "uuid-9999"}
 	existing := GetExistingMangaUUIDs(uuids)
@@ -112,9 +112,7 @@ func TestGetExistingMangaUUIDs(t *testing.T) {
 }
 
 func TestGetExistingMangaUUIDs_Chunking(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	internal.DB = db
+	setupTestDB(t)
 
 	// setupTestDB adds 1000 UUIDs (uuid-0 to uuid-999)
 	// We pass 1100 UUIDs to test chunking (chunk size is 900)

--- a/cmd/mangadex/helpers_test.go
+++ b/cmd/mangadex/helpers_test.go
@@ -18,26 +18,27 @@ func init() {
 	}
 }
 
-func setupTestDB() *sql.DB {
+func setupTestDB(tb testing.TB) *sql.DB {
+	tb.Helper()
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
-		panic(err)
+		tb.Fatal(err)
 	}
 	_, err = db.Exec("CREATE TABLE " + internal.TableManga + " (UUID TEXT PRIMARY KEY, JSON TEXT, DATE TEXT)")
 	if err != nil {
-		panic(err)
+		tb.Fatal(err)
 	}
 
 	stmt, err := db.Prepare("INSERT INTO " + internal.TableManga + " (UUID, JSON, DATE) VALUES (?, ?, ?)")
 	if err != nil {
-		panic(err)
+		tb.Fatal(err)
 	}
 	defer stmt.Close()
 
 	for _, uuid := range testUUIDs {
 		_, err = stmt.Exec(uuid, "{}", "2023-01-01")
 		if err != nil {
-			panic(err)
+			tb.Fatal(err)
 		}
 	}
 
@@ -45,7 +46,7 @@ func setupTestDB() *sql.DB {
 }
 
 func BenchmarkExistsInDatabase(b *testing.B) {
-	db := setupTestDB()
+	db := setupTestDB(b)
 	defer db.Close()
 	internal.DB = db
 
@@ -56,7 +57,7 @@ func BenchmarkExistsInDatabase(b *testing.B) {
 }
 
 func BenchmarkGetExistingMangaUUIDs(b *testing.B) {
-	db := setupTestDB()
+	db := setupTestDB(b)
 	defer db.Close()
 	internal.DB = db
 
@@ -73,7 +74,7 @@ func BenchmarkGetExistingMangaUUIDs(b *testing.B) {
 }
 
 func TestExistsInDatabase(t *testing.T) {
-	db := setupTestDB()
+	db := setupTestDB(t)
 	defer db.Close()
 	internal.DB = db
 
@@ -89,7 +90,7 @@ func TestExistsInDatabase(t *testing.T) {
 }
 
 func TestGetExistingMangaUUIDs(t *testing.T) {
-	db := setupTestDB()
+	db := setupTestDB(t)
 	defer db.Close()
 	internal.DB = db
 
@@ -111,7 +112,7 @@ func TestGetExistingMangaUUIDs(t *testing.T) {
 }
 
 func TestGetExistingMangaUUIDs_Chunking(t *testing.T) {
-	db := setupTestDB()
+	db := setupTestDB(t)
 	defer db.Close()
 	internal.DB = db
 


### PR DESCRIPTION
This PR replaces the use of `panic` in the `setupTestDB` test helper within the `cmd/mangadex` package with `tb.Fatal`. 

### 🎯 What:
- Refactored `setupTestDB(tb testing.TB)` to accept the testing interface.
- Replaced `panic(err)` with `tb.Fatal(err)`.
- Added `tb.Helper()` for accurate error reporting.
- Updated all callers in `cmd/mangadex/helpers_test.go`.

### 💡 Why:
Using `panic` in test helpers is discouraged as it crashes the entire test process and provides less useful output than `t.Fatal`. By passing `testing.TB`, we allow the Go test runner to catch the failure, report it clearly, and continue with other tests if possible. `tb.Helper()` ensures that the reported file and line number point to the actual test that failed, rather than the helper function itself.

### ✅ Verification:
- Code changes were verified through manual inspection.
- The pattern follows existing idiomatic test helpers in other parts of the codebase (e.g., `cmd/calculate/helpers_test.go`).
- Attempted to run `go test -v -bench=. ./cmd/mangadex/`, but encountered network timeouts for external dependencies in the environment.

### ✨ Result:
Improved test maintainability and better error reporting for MangaDex related tests and benchmarks.

---
*PR created automatically by Jules for task [16669431605104785655](https://jules.google.com/task/16669431605104785655) started by @nonproto*