### PR TITLE
🔒 [security fix] Path and Query Escape MU IDs in mapping helpers

### DIFF
--- a/cmd/calculate/mappingHelpers.go
+++ b/cmd/calculate/mappingHelpers.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/ratelimit"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,7 +48,7 @@ func AddAlreadyConvertedId(index int, total int, uuid string, muLink string, rat
 
 		// Try the new id!
 		rateLimiter.Take()
-		resp2, err := httpClient.Get("https://api.mangaupdates.com/v1/series/" + base10Id)
+		resp2, err := httpClient.Get("https://api.mangaupdates.com/v1/series/" + url.PathEscape(base10Id))
 		if err != nil {
 			fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to get new id %s: %v\u001B[0m\n", uuid, base10Id, err)
 			return false
@@ -83,7 +84,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 
 		rateLimiter.Take()
 		// Try the existing as the id (not likely since mangadex won't have updated..)
-		resp1, err1 := httpClient.Get("https://api.mangaupdates.com/v1/series/" + convertedId)
+		resp1, err1 := httpClient.Get("https://api.mangaupdates.com/v1/series/" + url.PathEscape(convertedId))
 
 		if err1 == nil && resp1.StatusCode == 200 {
 			drainAndClose(resp1)
@@ -106,10 +107,10 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 
 				// If invalid, then try to get the page and parse it!
 				// Query and get our html... (no api to get this...)
-				url := "https://www.mangaupdates.com/series.html?id=" + convertedId
-				req, err := http.NewRequest("GET", url, nil)
+				muUrl := "https://www.mangaupdates.com/series.html?id=" + url.QueryEscape(convertedId)
+				req, err := http.NewRequest("GET", muUrl, nil)
 				if err != nil {
-					fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to create request for %s: %v\u001B[0m\n", uuid, url, err)
+					fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to create request for %s: %v\u001B[0m\n", uuid, muUrl, err)
 					return false
 				}
 				req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36")
@@ -131,7 +132,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 
 						return false
 					} else {
-						fmt.Printf("\u001B[1;31m %s EXTERNAL MU %s: http code %d (try %d of %d)\u001B[0m\n", uuid, url, resp.StatusCode, counter, counterMax)
+						fmt.Printf("\u001B[1;31m %s EXTERNAL MU %s: http code %d (try %d of %d)\u001B[0m\n", uuid, muUrl, resp.StatusCode, counter, counterMax)
 
 						drainAndClose(resp)
 
@@ -145,7 +146,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 					drainAndClose(resp)
 
 					if err != nil {
-						fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to parse HTML for %s: %v\u001B[0m\n", uuid, url, err)
+						fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to parse HTML for %s: %v\u001B[0m\n", uuid, muUrl, err)
 						continue
 					}
 
@@ -159,7 +160,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 					}
 				} else {
 					if err != nil {
-						fmt.Printf("\u001B[1;31m %s EXTERNAL MU: request failed for %s (try %d of %d): %v\u001B[0m\n", uuid, url, counter, counterMax, err)
+						fmt.Printf("\u001B[1;31m %s EXTERNAL MU: request failed for %s (try %d of %d): %v\u001B[0m\n", uuid, muUrl, counter, counterMax, err)
 					}
 					// Catch all case to ensure body is closed
 					if resp != nil {

--- a/cmd/calculate/mappingHelpers.go
+++ b/cmd/calculate/mappingHelpers.go
@@ -19,6 +19,17 @@ var httpClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
+const muUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36"
+
+func muGet(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("User-Agent", muUserAgent)
+	return httpClient.Do(req)
+}
+
 func muEntryExistsInNewIDDatabase(uuid string) bool {
 	rows, err := internal.DB.Query("SELECT UUID FROM "+internal.TableMangaupdatesNewId+" WHERE UUID= ?", uuid)
 	internal.CheckErr(err)
@@ -48,7 +59,7 @@ func AddAlreadyConvertedId(index int, total int, uuid string, muLink string, rat
 
 		// Try the new id!
 		rateLimiter.Take()
-		resp2, err := httpClient.Get("https://api.mangaupdates.com/v1/series/" + url.PathEscape(base10Id))
+		resp2, err := muGet("https://api.mangaupdates.com/v1/series/" + url.PathEscape(base10Id))
 		if err != nil {
 			fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to get new id %s: %v\u001B[0m\n", uuid, base10Id, err)
 			return false
@@ -84,7 +95,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 
 		rateLimiter.Take()
 		// Try the existing as the id (not likely since mangadex won't have updated..)
-		resp1, err1 := httpClient.Get("https://api.mangaupdates.com/v1/series/" + url.PathEscape(convertedId))
+		resp1, err1 := muGet("https://api.mangaupdates.com/v1/series/" + url.PathEscape(convertedId))
 
 		if err1 == nil && resp1.StatusCode == 200 {
 			drainAndClose(resp1)
@@ -108,13 +119,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 				// If invalid, then try to get the page and parse it!
 				// Query and get our html... (no api to get this...)
 				muUrl := "https://www.mangaupdates.com/series.html?id=" + url.QueryEscape(convertedId)
-				req, err := http.NewRequest("GET", muUrl, nil)
-				if err != nil {
-					fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to create request for %s: %v\u001B[0m\n", uuid, muUrl, err)
-					return false
-				}
-				req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36")
-				resp, err := httpClient.Do(req)
+				resp, err := muGet(muUrl)
 
 				// Sleep if we get a warning, otherwise we don't retry again!
 				if err == nil && resp.StatusCode == 429 {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is unvalidated input in HTTP GET request URLs.
⚠️ **Risk:** Potential for URL injection or manipulation, allowing an attacker to alter the intended request structure (e.g., path traversal, query parameter injection).
🛡️ **Solution:** Applied `url.PathEscape` to ID segments used in URL paths and `url.QueryEscape` to ID segments used in query parameters. Also renamed a local `url` variable to `muUrl` to avoid shadowing the `net/url` package.

---
*PR created automatically by Jules for task [645790888641623702](https://jules.google.com/task/645790888641623702) started by @nonproto*