### PR TITLE
🧹 refactor: simplify init in cmd/calculate/similar.go

### DIFF
--- a/cmd/calculate/similar.go
+++ b/cmd/calculate/similar.go
@@ -46,18 +46,25 @@ var (
 
 func init() {
 	calculateCmd.AddCommand(similarCmd)
-	similarCmd.Flags().BoolP("skipped", "s", false, "Print out reason a match was skipped")
-	similarCmd.Flags().BoolP("debug", "d", false, "Run a set of debug entries only.")
-	similarCmd.Flags().BoolP("export", "e", false, "Only export results, don't recalculate similar.")
-	similarCmd.Flags().IntP("threads", "t", 1000, "Change the batch processing amount")
-	similarCmd.Flags().BoolP("verbose", "v", false, "Print detailed match information")
+	initSimilarFlags()
+	initStopWords()
+}
 
+func initStopWords() {
 	// Pre-process stop words once
 	cachedStopWords = append([]string(nil), similar.StopWords...)
 	stemmer.StemMultipleMutate(&cachedStopWords)
 	for i := range cachedStopWords {
 		cachedStopWords[i] = strings.ToLower(cachedStopWords[i])
 	}
+}
+
+func initSimilarFlags() {
+	similarCmd.Flags().BoolP("skipped", "s", false, "Print out reason a match was skipped")
+	similarCmd.Flags().BoolP("debug", "d", false, "Run a set of debug entries only.")
+	similarCmd.Flags().BoolP("export", "e", false, "Only export results, don't recalculate similar.")
+	similarCmd.Flags().IntP("threads", "t", 1000, "Change the batch processing amount")
+	similarCmd.Flags().BoolP("verbose", "v", false, "Print detailed match information")
 }
 
 func runSimilar(cmd *cobra.Command, args []string) {

--- a/cmd/mangadex/helpers_test.go
+++ b/cmd/mangadex/helpers_test.go
@@ -1,8 +1,8 @@
 package mangadex
 
 import (
-	"encoding/json"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 


### PR DESCRIPTION
### 🎯 What: The code health issue addressed
Refactored the `init` function in `cmd/calculate/similar.go` to reduce its complexity.

### 💡 Why: How this improves maintainability
Moving flag binding and stop-word pre-processing into separate functions makes the `init` function cleaner and more readable. It follows better coding practices by isolating distinct initialization tasks into their own scopes.

### ✅ Verification: How you confirmed the change is safe
- Manually verified the content of `cmd/calculate/similar.go` to ensure all logic was correctly moved and functions are called in `init`.
- Ran `go fmt` to ensure correct formatting.
- Obtained a positive code review confirming the refactor is safe and preserves original behavior.
- (Note: Full `go test` was limited by network restrictions on dependency downloads in the sandbox, but the structural change is logic-neutral).

### ✨ Result: The improvement achieved
A more maintainable and readable `init` block in the `similar` command implementation.

---
*PR created automatically by Jules for task [1273077128298823587](https://jules.google.com/task/1273077128298823587) started by @nonproto*