### PR TITLE
⚡ Bolt: optimize GetExistingMangaUUIDs using json_each bulk check

### DIFF
--- a/cmd/mangadex/add.go
+++ b/cmd/mangadex/add.go
@@ -49,7 +49,8 @@ func runAdd(cmd *cobra.Command, args []string) {
 			uuids[i] = apiManga.Id
 		}
 
-		existingUUIDs := GetExistingMangaUUIDs(uuids)
+		existingUUIDs, err := GetExistingMangaUUIDs(uuids)
+		internal.CheckErr(err)
 
 		var toUpsert []mangadex.Manga
 		for _, apiManga := range mangaList.Data {

--- a/cmd/mangadex/helpers.go
+++ b/cmd/mangadex/helpers.go
@@ -110,30 +110,37 @@ func ExistsInDatabase(uuid string) bool {
 	return rows.Next()
 }
 
-func GetExistingMangaUUIDs(uuids []string) map[string]bool {
+func GetExistingMangaUUIDs(uuids []string) (map[string]bool, error) {
 	if len(uuids) == 0 {
-		return make(map[string]bool)
+		return make(map[string]bool), nil
 	}
 
-	existing := make(map[string]bool)
+	existing := make(map[string]bool, len(uuids))
 
 	jsonUUIDs, err := json.Marshal(uuids)
-	internal.CheckErr(err)
+	if err != nil {
+		return nil, err
+	}
 
 	query := fmt.Sprintf("SELECT UUID FROM %s WHERE UUID IN (SELECT value FROM json_each(?))", internal.TableManga)
 	rows, err := internal.DB.Query(query, string(jsonUUIDs))
-	internal.CheckErr(err)
+	if err != nil {
+		return nil, err
+	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var uuid string
-		err := rows.Scan(&uuid)
-		internal.CheckErr(err)
+		if err := rows.Scan(&uuid); err != nil {
+			return nil, err
+		}
 		existing[uuid] = true
 	}
-	internal.CheckErr(rows.Err())
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
-	return existing
+	return existing, nil
 }
 
 func UpsertManga(apiManga mangadex.Manga) {

--- a/cmd/mangadex/helpers.go
+++ b/cmd/mangadex/helpers.go
@@ -116,41 +116,23 @@ func GetExistingMangaUUIDs(uuids []string) map[string]bool {
 	}
 
 	existing := make(map[string]bool)
-	const chunkSize = 900 // SQLite's default parameter limit is 999, using a safe margin.
 
-	for i := 0; i < len(uuids); i += chunkSize {
-		end := i + chunkSize
-		if end > len(uuids) {
-			end = len(uuids)
-		}
-		chunk := uuids[i:end]
+	jsonUUIDs, err := json.Marshal(uuids)
+	internal.CheckErr(err)
 
-		if len(chunk) == 0 {
-			continue
-		}
+	query := fmt.Sprintf("SELECT UUID FROM %s WHERE UUID IN (SELECT value FROM json_each(?))", internal.TableManga)
+	rows, err := internal.DB.Query(query, string(jsonUUIDs))
+	internal.CheckErr(err)
+	defer rows.Close()
 
-		placeholders := make([]string, len(chunk))
-		args := make([]any, len(chunk))
-		for j, uuid := range chunk {
-			placeholders[j] = "?"
-			args[j] = uuid
-		}
-
-		query := fmt.Sprintf("SELECT UUID FROM %s WHERE UUID IN (%s)", internal.TableManga, strings.Join(placeholders, ","))
-		rows, err := internal.DB.Query(query, args...)
+	for rows.Next() {
+		var uuid string
+		err := rows.Scan(&uuid)
 		internal.CheckErr(err)
-
-		func() {
-			defer rows.Close()
-			for rows.Next() {
-				var uuid string
-				err := rows.Scan(&uuid)
-				internal.CheckErr(err)
-				existing[uuid] = true
-			}
-			internal.CheckErr(rows.Err())
-		}()
+		existing[uuid] = true
 	}
+	internal.CheckErr(rows.Err())
+
 	return existing
 }
 

--- a/cmd/mangadex/helpers_test.go
+++ b/cmd/mangadex/helpers_test.go
@@ -75,7 +75,7 @@ func BenchmarkGetExistingMangaUUIDs(b *testing.B) {
 		if end > 1000 {
 			end = 1000
 		}
-		GetExistingMangaUUIDs(testUUIDs[start:end])
+		_, _ = GetExistingMangaUUIDs(testUUIDs[start:end])
 	}
 }
 
@@ -97,7 +97,10 @@ func TestGetExistingMangaUUIDs(t *testing.T) {
 	setupTestDB(t)
 
 	uuids := []string{"uuid-1", "uuid-2", "uuid-9999"}
-	existing := GetExistingMangaUUIDs(uuids)
+	existing, err := GetExistingMangaUUIDs(uuids)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if !existing["uuid-1"] {
 		t.Error("uuid-1 should exist")
@@ -117,13 +120,16 @@ func TestGetExistingMangaUUIDs_Chunking(t *testing.T) {
 	setupTestDB(t)
 
 	// setupTestDB adds 1000 UUIDs (uuid-0 to uuid-999)
-	// We pass 1100 UUIDs to test chunking (chunk size is 900)
+	// We pass 1100 UUIDs to test the json_each implementation
 	uuids := make([]string, 1100)
 	for i := 0; i < 1100; i++ {
 		uuids[i] = fmt.Sprintf("uuid-%d", i)
 	}
 
-	existing := GetExistingMangaUUIDs(uuids)
+	existing, err := GetExistingMangaUUIDs(uuids)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// uuid-0 to uuid-999 should exist (1000)
 	// uuid-1000 to uuid-1099 should not exist (100)


### PR DESCRIPTION
### ⚡ Performance Improvement: Bulk UUID Check

**What:**
The `GetExistingMangaUUIDs` function was previously iterating over UUIDs in chunks of 900, performing a separate `SELECT` query for each chunk. I have replaced this with a single query that uses SQLite's `json_each` function. The input slice of UUIDs is marshaled into a JSON array and passed as a single parameter to the query.

**Why:**
This change addresses an inefficient query pattern. Even though it was chunked, it still required multiple database roundtrips for large sets of UUIDs. SQLite's `json_each` allows for an efficient bulk membership check without hitting the `SQLITE_LIMIT_VARIABLE_NUMBER` (default 999).

**Measured Improvement:**
- **Query Complexity:** Reduced from O(N/900) to O(1) database roundtrips.
- **Overhead:** Eliminated dynamic generation of placeholder strings and repeated query preparation/execution.
- **Environment Note:** Empirical benchmarks were attempted but blocked by network restrictions in the sandbox environment preventing dependency resolution. However, the theoretical gain from reducing I/O and query parsing overhead is significant for large datasets.

**Verification:**
- Verified `json_each` support in the sandbox's SQLite environment.
- Manually reviewed the code logic and ensured proper resource cleanup (`rows.Close()`).
- Confirmed that `encoding/json` and `strings` imports are correctly managed.
- Deleted temporary verification scripts.

---
*PR created automatically by Jules for task [14070788021532708780](https://jules.google.com/task/14070788021532708780) started by @nonproto*