### PR TITLE
🔒 Fix SQL Injection in table name parameters

### DIFF
--- a/cmd/calculate/mappingHelpers.go
+++ b/cmd/calculate/mappingHelpers.go
@@ -43,6 +43,9 @@ func upsertNewMuId(uuid string, id string) {
 }
 
 func UpsertGeneric(tx *sql.Tx, table string, uuid string, id string) error {
+	if !internal.IsValidMappingTable(table) {
+		return fmt.Errorf("UpsertGeneric: invalid table name %s", table)
+	}
 	_, err := tx.Exec("INSERT INTO "+table+" (UUID, ID) VALUES (?, ?) ON CONFLICT (UUID) DO UPDATE SET ID=excluded.ID", uuid, id)
 	return err
 }

--- a/cmd/calculate/mappings.go
+++ b/cmd/calculate/mappings.go
@@ -186,13 +186,13 @@ func syncMangaBakaFromSeries() {
 	fmt.Println("\nSyncing missing MangaBaka entries from remote SQLite API...")
 
 	fmt.Println("Loading mapping tables into memory...")
-	anilistMap := loadMappingIntoMap("ANILIST")
-	malMap := loadMappingIntoMap("MYANIMELIST")
-	kitsuMap := loadMappingIntoMap("KITSU")
-	animePlanetMap := loadMappingIntoMap("ANIME_PLANET")
-	muOldMap := loadMappingIntoMap("MANGAUPDATES_OLD")
-	muNewMap := loadMappingIntoMap("MANGAUPDATES_NEW")
-	mangaBakaMap := loadMappingIntoMap("MANGABAKA")
+	anilistMap := loadMappingIntoMap(internal.TableAnilist)
+	malMap := loadMappingIntoMap(internal.TableMyanimelist)
+	kitsuMap := loadMappingIntoMap(internal.TableKitsu)
+	animePlanetMap := loadMappingIntoMap(internal.TableAnimePlanet)
+	muOldMap := loadMappingIntoMap(internal.TableMangaupdates)
+	muNewMap := loadMappingIntoMap(internal.TableMangaupdatesNewId)
+	mangaBakaMap := loadMappingIntoMap(internal.TableMangaBaka)
 
 	downloadUrl := "https://api.mangabaka.dev/v1/database/series.sqlite.tar.gz"
 	fmt.Printf("Downloading and extracting %s...\n", downloadUrl)
@@ -345,6 +345,11 @@ func syncMangaBakaFromSeries() {
 
 func loadMappingIntoMap(tableName string) map[string]string {
 	m := make(map[string]string)
+
+	if !internal.IsValidMappingTable(tableName) {
+		fmt.Printf("loadMappingIntoMap: invalid table name %s\n", tableName)
+		return m
+	}
 
 	query := fmt.Sprintf("SELECT ID, UUID FROM %s", tableName)
 	rows, err := internal.DB.Query(query)

--- a/cmd/neko/neko.go
+++ b/cmd/neko/neko.go
@@ -117,7 +117,7 @@ func setNekoField(nekoEntry *internal.DbNeko, table, value string) {
 
 func getAllMappings(table string) map[string]string {
 	if !internal.IsValidMappingTable(table) {
-		fmt.Printf("getAllMappings: invalid table name %s\n", table)
+		fmt.Fprintf(os.Stderr, "getAllMappings: invalid table name %s\n", table)
 		return make(map[string]string)
 	}
 
@@ -131,7 +131,7 @@ func getAllMappings(table string) map[string]string {
 		if err := rows.Scan(&uuid, &id); err == nil {
 			mapping[uuid] = id
 		} else {
-			fmt.Printf("Warning: failed to scan row in table %s: %v\n", table, err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to scan row in table %s: %v\n", table, err)
 		}
 	}
 	internal.CheckErr(rows.Err())

--- a/cmd/neko/neko.go
+++ b/cmd/neko/neko.go
@@ -116,6 +116,11 @@ func setNekoField(nekoEntry *internal.DbNeko, table, value string) {
 }
 
 func getAllMappings(table string) map[string]string {
+	if !internal.IsValidMappingTable(table) {
+		fmt.Printf("getAllMappings: invalid table name %s\n", table)
+		return make(map[string]string)
+	}
+
 	rows, err := internal.DB.Query("SELECT UUID, ID FROM " + table)
 	internal.CheckErr(err)
 	defer rows.Close()

--- a/internal/databases.go
+++ b/internal/databases.go
@@ -99,3 +99,13 @@ func GetMangaCount() (int, error) {
 	}
 	return count, nil
 }
+
+// IsValidMappingTable returns true if the table name is a valid mapping table.
+// This is used to prevent SQL injection when table names are used in queries.
+func IsValidMappingTable(table string) bool {
+	switch table {
+	case TableAnilist, TableAnimePlanet, TableBookWalker, TableKitsu, TableMyanimelist, TableMangaupdates, TableMangaupdatesNewId, TableNovelUpdates, TableMangaBaka:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
🎯 **What:** Fixed multiple SQL injection vulnerabilities where table names were dynamically inserted into queries using string concatenation or `fmt.Sprintf`.
⚠️ **Risk:** Potential for unauthorized data access, data modification, or information leakage if a malicious table name were passed to these functions.
🛡️ **Solution:** Implemented a centralized allowlist (whitelist) of safe table names and validated all dynamic table name parameters against it. Switched to using defined constants for table names to reduce errors.

---
*PR created automatically by Jules for task [14194095516844589265](https://jules.google.com/task/14194095516844589265) started by @nonproto*