### PR TITLE
fix: resolve compilation errors in mangadex and calculate packages

### DIFF
--- a/cmd/calculate/mappingHelpers.go
+++ b/cmd/calculate/mappingHelpers.go
@@ -102,7 +102,7 @@ func CheckAndAddLegacyId(index int, total int, uuid string, muLink string, rateL
 
 			fmt.Printf("%d/%d manga %s -> mu id of %d -> is old MU id...\n", index+1, total, uuid, idOriginal)
 			upsertNewMuId(uuid, convertedId)
-
+			return true
 		} else {
 			if err1 != nil {
 				fmt.Printf("\u001B[1;31m %s EXTERNAL MU: failed to get legacy id %s: %v\u001B[0m\n", uuid, convertedId, err1)

--- a/cmd/calculate/mappingHelpers_test.go
+++ b/cmd/calculate/mappingHelpers_test.go
@@ -149,6 +149,7 @@ func TestCheckAndAddLegacyId(t *testing.T) {
 			},
 			expectedResult: false,
 			verify: func(t *testing.T) {
+				CloseDebugFiles()
 				debugFile := filepath.Join("debug", "BadMUIds.txt")
 				t.Cleanup(func() { _ = os.Remove(debugFile) })
 

--- a/cmd/mangadex/add.go
+++ b/cmd/mangadex/add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/antihax/optional"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/similar-manga/similar/internal"
 	"github.com/similar-manga/similar/mangadex"
 	"github.com/spf13/cobra"
 	"go.uber.org/ratelimit"


### PR DESCRIPTION
Fixes build/compilation errors reported in the codebase. Specifically, adds the missing `internal` import to `cmd/mangadex/add.go` and fixes a missing return and file locking bug in the `cmd/calculate` tests to ensure successful test completion.

---
*PR created automatically by Jules for task [6250382835932369334](https://jules.google.com/task/6250382835932369334) started by @nonproto*