### PR TITLE
🧪 [testing improvement] Add unit tests for MatchMinHeap

### DIFF
--- a/cmd/calculate/similar.go
+++ b/cmd/calculate/similar.go
@@ -554,24 +554,6 @@ func invalidForProcessing(match customMatch, currentIdx int, current, target int
 	return false, ""
 }
 
-type customMatch struct {
-	ID                                  int
-	Distance, DistanceTag, DistanceDesc float64
-}
-
-type MatchMinHeap []customMatch
-
-func (h MatchMinHeap) Len() int            { return len(h) }
-func (h MatchMinHeap) Less(i, j int) bool  { return h[i].Distance < h[j].Distance }
-func (h MatchMinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h *MatchMinHeap) Push(x interface{}) { *h = append(*h, x.(customMatch)) }
-func (h *MatchMinHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
-}
 
 func exportSimilar() {
 	if err := os.RemoveAll("data/similar/"); err != nil {

--- a/cmd/calculate/similar_heap.go
+++ b/cmd/calculate/similar_heap.go
@@ -10,8 +10,8 @@ type MatchMinHeap []customMatch
 func (h MatchMinHeap) Len() int            { return len(h) }
 func (h MatchMinHeap) Less(i, j int) bool  { return h[i].Distance < h[j].Distance }
 func (h MatchMinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h *MatchMinHeap) Push(x interface{}) { *h = append(*h, x.(customMatch)) }
-func (h *MatchMinHeap) Pop() interface{} {
+func (h *MatchMinHeap) Push(x any) { *h = append(*h, x.(customMatch)) }
+func (h *MatchMinHeap) Pop() any {
 	old := *h
 	n := len(old)
 	x := old[n-1]

--- a/cmd/calculate/similar_heap.go
+++ b/cmd/calculate/similar_heap.go
@@ -1,0 +1,20 @@
+package calculate
+
+type customMatch struct {
+	ID                                  int
+	Distance, DistanceTag, DistanceDesc float64
+}
+
+type MatchMinHeap []customMatch
+
+func (h MatchMinHeap) Len() int            { return len(h) }
+func (h MatchMinHeap) Less(i, j int) bool  { return h[i].Distance < h[j].Distance }
+func (h MatchMinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MatchMinHeap) Push(x interface{}) { *h = append(*h, x.(customMatch)) }
+func (h *MatchMinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/cmd/calculate/similar_heap_test.go
+++ b/cmd/calculate/similar_heap_test.go
@@ -31,14 +31,19 @@ func TestMatchMinHeap(t *testing.T) {
 	}
 
 	// Test Pop order (Min-Heap: smallest distance first)
-	expectedDistances := []float64{0.1, 0.3, 0.5, 0.8}
-	for _, expected := range expectedDistances {
+	expected := []customMatch{
+		{ID: 2, Distance: 0.1},
+		{ID: 4, Distance: 0.3},
+		{ID: 1, Distance: 0.5},
+		{ID: 3, Distance: 0.8},
+	}
+	for _, exp := range expected {
 		if h.Len() == 0 {
 			t.Fatal("Heap unexpectedly empty")
 		}
 		m := heap.Pop(h).(customMatch)
-		if m.Distance != expected {
-			t.Errorf("Expected distance %f, got %f", expected, m.Distance)
+		if m.ID != exp.ID || m.Distance != exp.Distance {
+			t.Errorf("Expected %+v, got %+v", exp, m)
 		}
 	}
 

--- a/cmd/calculate/similar_heap_test.go
+++ b/cmd/calculate/similar_heap_test.go
@@ -1,0 +1,75 @@
+package calculate
+
+import (
+	"container/heap"
+	"testing"
+)
+
+func TestMatchMinHeap(t *testing.T) {
+	h := &MatchMinHeap{}
+	heap.Init(h)
+
+	// Test Len() on empty heap
+	if h.Len() != 0 {
+		t.Errorf("Expected Len 0, got %d", h.Len())
+	}
+
+	// Test Push and Len
+	matches := []customMatch{
+		{ID: 1, Distance: 0.5},
+		{ID: 2, Distance: 0.1},
+		{ID: 3, Distance: 0.8},
+		{ID: 4, Distance: 0.3},
+	}
+
+	for _, m := range matches {
+		heap.Push(h, m)
+	}
+
+	if h.Len() != len(matches) {
+		t.Errorf("Expected Len %d, got %d", len(matches), h.Len())
+	}
+
+	// Test Pop order (Min-Heap: smallest distance first)
+	expectedDistances := []float64{0.1, 0.3, 0.5, 0.8}
+	for _, expected := range expectedDistances {
+		if h.Len() == 0 {
+			t.Fatal("Heap unexpectedly empty")
+		}
+		m := heap.Pop(h).(customMatch)
+		if m.Distance != expected {
+			t.Errorf("Expected distance %f, got %f", expected, m.Distance)
+		}
+	}
+
+	if h.Len() != 0 {
+		t.Errorf("Expected Len 0 after all pops, got %d", h.Len())
+	}
+}
+
+func TestMatchMinHeap_Less(t *testing.T) {
+	h := MatchMinHeap{
+		{ID: 1, Distance: 0.5},
+		{ID: 2, Distance: 0.1},
+	}
+
+	if !h.Less(1, 0) {
+		t.Error("h[1].Distance (0.1) should be less than h[0].Distance (0.5)")
+	}
+	if h.Less(0, 1) {
+		t.Error("h[0].Distance (0.5) should NOT be less than h[1].Distance (0.1)")
+	}
+}
+
+func TestMatchMinHeap_Swap(t *testing.T) {
+	h := MatchMinHeap{
+		{ID: 1, Distance: 0.5},
+		{ID: 2, Distance: 0.1},
+	}
+
+	h.Swap(0, 1)
+
+	if h[0].ID != 2 || h[1].ID != 1 {
+		t.Errorf("Swap failed: h[0].ID=%d, h[1].ID=%d", h[0].ID, h[1].ID)
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `MatchMinHeap` implementation used in similarity calculations.
📊 **Coverage:** Covered all methods (`Len`, `Less`, `Swap`, `Push`, `Pop`) of the `MatchMinHeap` type, verifying correct element ordering and heap property maintenance.
✨ **Result:** Increased test coverage for the core similarity ranking logic and improved code organization by isolating the heap data structure.

---
*PR created automatically by Jules for task [17897042838009420526](https://jules.google.com/task/17897042838009420526) started by @nonproto*