### PR TITLE
fix: output binary as similar in AddAndUpdateMetadata workflow

### DIFF
--- a/.github/workflows/AddAndUpdateMetadata.yml
+++ b/.github/workflows/AddAndUpdateMetadata.yml
@@ -23,7 +23,7 @@ jobs:
         run: go get .
 
       - name: Build
-        run: go build -v
+        run: go build -v -o similar
 
       - name: Setup DB
         run: ./similar init


### PR DESCRIPTION
The github action step "Setup DB" in `.github/workflows/AddAndUpdateMetadata.yml` was failing with `./similar: No such file or directory`.

This was because the previous `go build` step, without an output name specified, output the binary as `similar-processor` instead of `similar` (as `similar-processor` is the module name).

This PR fixes the issue by updating the `go build` command in the github action to `go build -v -o similar`.

---
*PR created automatically by Jules for task [5662123946407161131](https://jules.google.com/task/5662123946407161131) started by @nonproto*