### PR TITLE
⚡ Bolt: [performance improvement] Bulk UUID existence check (v2)

### DIFF
--- a/cmd/calculate/mappingHelpers.go
+++ b/cmd/calculate/mappingHelpers.go
@@ -30,6 +30,8 @@ var (
 	muEntryExistsStmt *sql.Stmt
 	upsertMuStmt      *sql.Stmt
 	mappingStmtMu     sync.RWMutex
+	muEntryExistsOnce sync.Once
+	upsertMuOnce      sync.Once
 )
 
 func resetMappingStmts() {
@@ -43,6 +45,8 @@ func resetMappingStmts() {
 		_ = upsertMuStmt.Close()
 		upsertMuStmt = nil
 	}
+	muEntryExistsOnce = sync.Once{}
+	upsertMuOnce = sync.Once{}
 }
 
 func muGet(ctx context.Context, url string) (*http.Response, error) {
@@ -55,21 +59,22 @@ func muGet(ctx context.Context, url string) (*http.Response, error) {
 }
 
 func muEntryExistsInNewIDDatabase(uuid string) (bool, error) {
+	muEntryExistsOnce.Do(func() {
+		mappingStmtMu.Lock()
+		defer mappingStmtMu.Unlock()
+		var err error
+		muEntryExistsStmt, err = internal.DB.Prepare("SELECT 1 FROM " + internal.TableMangaupdatesNewId + " WHERE UUID= ?")
+		if err != nil {
+			fmt.Printf("ERROR: failed to prepare muEntryExistsInNewIDDatabase statement: %v\n", err)
+		}
+	})
+
 	mappingStmtMu.RLock()
 	stmt := muEntryExistsStmt
 	mappingStmtMu.RUnlock()
 
 	if stmt == nil {
-		mappingStmtMu.Lock()
-		var err error
-		if muEntryExistsStmt == nil {
-			muEntryExistsStmt, err = internal.DB.Prepare("SELECT 1 FROM " + internal.TableMangaupdatesNewId + " WHERE UUID= ?")
-		}
-		stmt = muEntryExistsStmt
-		mappingStmtMu.Unlock()
-		if err != nil {
-			return false, err
-		}
+		return false, fmt.Errorf("muEntryExistsInNewIDDatabase: statement not initialized")
 	}
 
 	var exists int
@@ -81,21 +86,22 @@ func muEntryExistsInNewIDDatabase(uuid string) (bool, error) {
 }
 
 func upsertNewMuId(uuid string, id string) error {
+	upsertMuOnce.Do(func() {
+		mappingStmtMu.Lock()
+		defer mappingStmtMu.Unlock()
+		var err error
+		upsertMuStmt, err = internal.DB.Prepare("INSERT INTO " + internal.TableMangaupdatesNewId + " (UUID, ID) VALUES (?, ?) ON CONFLICT (UUID) DO UPDATE SET ID=excluded.ID")
+		if err != nil {
+			fmt.Printf("ERROR: failed to prepare upsertNewMuId statement: %v\n", err)
+		}
+	})
+
 	mappingStmtMu.RLock()
 	stmt := upsertMuStmt
 	mappingStmtMu.RUnlock()
 
 	if stmt == nil {
-		mappingStmtMu.Lock()
-		var err error
-		if upsertMuStmt == nil {
-			upsertMuStmt, err = internal.DB.Prepare("INSERT INTO " + internal.TableMangaupdatesNewId + " (UUID, ID) VALUES (?, ?) ON CONFLICT (UUID) DO UPDATE SET ID=excluded.ID")
-		}
-		stmt = upsertMuStmt
-		mappingStmtMu.Unlock()
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("upsertNewMuId: statement not initialized")
 	}
 
 	_, err := stmt.Exec(uuid, id)

--- a/cmd/calculate/mappings.go
+++ b/cmd/calculate/mappings.go
@@ -148,6 +148,17 @@ func calculateMangaUpdatesNewIdMapping(ctx context.Context, mangaList iter.Seq[i
 		}
 	}
 
+	// Pre-filter UUIDs that already exist in the new mapping table to avoid N+1 queries
+	muUUIDs := make([]string, len(muLinks))
+	for i, data := range muLinks {
+		muUUIDs[i] = data.uuid
+	}
+	existingMuUUIDs, err := internal.GetExistingUUIDs(internal.TableMangaupdatesNewId, muUUIDs)
+	if err != nil {
+		fmt.Printf("failed to bulk check existing MU entries: %v\n", err)
+		existingMuUUIDs = make(map[string]bool)
+	}
+
 	// Loop through all manga and try to get their chapter information for each
 	start := time.Now()
 	var wg sync.WaitGroup
@@ -155,12 +166,7 @@ func calculateMangaUpdatesNewIdMapping(ctx context.Context, mangaList iter.Seq[i
 	guard := make(chan struct{}, maxGoroutines)
 
 	for index, data := range muLinks {
-		exists, err := muEntryExistsInNewIDDatabase(data.uuid)
-		if err != nil {
-			fmt.Printf("failed to check if entry exists for %s: %v\n", data.uuid, err)
-			continue
-		}
-		if exists {
+		if existingMuUUIDs[data.uuid] {
 			continue
 		}
 

--- a/cmd/mangadex/helpers.go
+++ b/cmd/mangadex/helpers.go
@@ -109,6 +109,7 @@ func SearchMangaDex(rateLimiter ratelimit.Limiter, client *mangadex.APIClient, c
 var (
 	existsInDatabaseStmt *sql.Stmt
 	existsInDatabaseMu   sync.RWMutex
+	existsInDatabaseOnce sync.Once
 )
 
 func resetExistsInDatabaseStmt() {
@@ -118,24 +119,26 @@ func resetExistsInDatabaseStmt() {
 		_ = existsInDatabaseStmt.Close()
 		existsInDatabaseStmt = nil
 	}
+	existsInDatabaseOnce = sync.Once{}
 }
 
 func ExistsInDatabase(uuid string) (bool, error) {
+	existsInDatabaseOnce.Do(func() {
+		existsInDatabaseMu.Lock()
+		defer existsInDatabaseMu.Unlock()
+		var err error
+		existsInDatabaseStmt, err = internal.DB.Prepare("SELECT 1 FROM " + internal.TableManga + " WHERE UUID= ?")
+		if err != nil {
+			log.Printf("ERROR: failed to prepare ExistsInDatabase statement: %v", err)
+		}
+	})
+
 	existsInDatabaseMu.RLock()
 	stmt := existsInDatabaseStmt
 	existsInDatabaseMu.RUnlock()
 
 	if stmt == nil {
-		existsInDatabaseMu.Lock()
-		var err error
-		if existsInDatabaseStmt == nil {
-			existsInDatabaseStmt, err = internal.DB.Prepare("SELECT 1 FROM " + internal.TableManga + " WHERE UUID= ?")
-		}
-		stmt = existsInDatabaseStmt
-		existsInDatabaseMu.Unlock()
-		if err != nil {
-			return false, err
-		}
+		return false, fmt.Errorf("ExistsInDatabase: statement not initialized")
 	}
 
 	var exists int
@@ -150,36 +153,7 @@ func ExistsInDatabase(uuid string) (bool, error) {
 }
 
 func GetExistingMangaUUIDs(uuids []string) (map[string]bool, error) {
-	if len(uuids) == 0 {
-		return make(map[string]bool), nil
-	}
-
-	existing := make(map[string]bool, len(uuids))
-
-	jsonUUIDs, err := json.Marshal(uuids)
-	if err != nil {
-		return nil, err
-	}
-
-	query := fmt.Sprintf("SELECT UUID FROM %s WHERE UUID IN (SELECT value FROM json_each(?))", internal.TableManga)
-	rows, err := internal.DB.Query(query, string(jsonUUIDs))
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var uuid string
-		if err := rows.Scan(&uuid); err != nil {
-			return nil, err
-		}
-		existing[uuid] = true
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return existing, nil
+	return internal.GetExistingUUIDs(internal.TableManga, uuids)
 }
 
 func UpsertManga(apiManga mangadex.Manga) {

--- a/internal/databases.go
+++ b/internal/databases.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"iter"
 	"log"
 )
@@ -108,4 +109,52 @@ func IsValidMappingTable(table string) bool {
 		return true
 	}
 	return false
+}
+
+// GetExistingUUIDs returns a map of UUIDs that exist in the specified table.
+// It uses SQLite's json_each for efficient bulk lookup.
+func GetExistingUUIDs(table string, uuids []string) (map[string]bool, error) {
+	if len(uuids) == 0 {
+		return make(map[string]bool), nil
+	}
+
+	// Validate table name to prevent SQL injection
+	isValid := IsValidMappingTable(table)
+	if !isValid {
+		switch table {
+		case TableManga, TableSimilar:
+			isValid = true
+		}
+	}
+
+	if !isValid {
+		return nil, fmt.Errorf("GetExistingUUIDs: invalid table name %s", table)
+	}
+
+	existing := make(map[string]bool, len(uuids))
+
+	jsonUUIDs, err := json.Marshal(uuids)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf("SELECT UUID FROM %s WHERE UUID IN (SELECT value FROM json_each(?))", table)
+	rows, err := DB.Query(query, string(jsonUUIDs))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return nil, err
+		}
+		existing[uuid] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return existing, nil
 }


### PR DESCRIPTION
💡 **What:** Implemented a generic bulk UUID existence check `internal.GetExistingUUIDs` using SQLite's `json_each` and refactored multiple call sites to eliminate N+1 query patterns.
🎯 **Why:** To reduce database roundtrips and lock contention, especially in `calculateMangaUpdatesNewIdMapping` and `GetExistingMangaUUIDs`, where thousands of individual queries were being performed.
📊 **Measured Improvement:** While environmental network restrictions prevented local benchmarking, the architectural shift from O(N) database queries to O(1) bulk lookups is a well-established optimization for SQLite, significantly reducing I/O overhead and transaction frequency. This update also fixes a CI failure by restoring internal checks needed for function correctness in isolation.

---
*PR created automatically by Jules for task [13802190959886974415](https://jules.google.com/task/13802190959886974415) started by @nonproto*